### PR TITLE
Use render_component when monkey_patch has been disabled

### DIFF
--- a/app/controllers/view_component/storybook/stories_controller.rb
+++ b/app/controllers/view_component/storybook/stories_controller.rb
@@ -41,6 +41,12 @@ module ViewComponent
         @story_config = @story_configs.find_story_config(story_name)
         head :not_found unless @story_config
       end
+
+      def render_component_method
+        ViewComponent::Base.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 ? :render : :render_component
+      end
+
+      helper_method :render_component_method
     end
   end
 end

--- a/app/views/view_component/storybook/stories/show.html.erb
+++ b/app/views/view_component/storybook/stories/show.html.erb
@@ -1,3 +1,4 @@
+<%- if ViewComponent::Base.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 -%>
 <%= render(@story.component) do |c| -%>
   <% @story.slots.each do |slot| -%>
     <%- slot.call do -%>
@@ -5,4 +6,14 @@
     <%- end -%>
   <%- end -%>
   <%- instance_eval(&@story.content_block) if @story.content_block -%>
+<%- end -%>
+<%- else -%>
+<%= render_component(@story.component) do |c| -%>
+  <% @story.slots.each do |slot| -%>
+    <%- slot.call do -%>
+      <%= instance_eval(&slot.content_block) if slot.content_block -%>
+    <%- end -%>
+  <%- end -%>
+  <%- instance_eval(&@story.content_block) if @story.content_block -%>
+<%- end -%>
 <%- end -%>

--- a/app/views/view_component/storybook/stories/show.html.erb
+++ b/app/views/view_component/storybook/stories/show.html.erb
@@ -1,19 +1,8 @@
-<%- if ViewComponent::Base.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 -%>
-<%= render(@story.component) do |c| -%>
+<%= send(render_component_method, @story.component) do |c| -%>
   <% @story.slots.each do |slot| -%>
     <%- slot.call do -%>
       <%= instance_eval(&slot.content_block) if slot.content_block -%>
     <%- end -%>
   <%- end -%>
   <%- instance_eval(&@story.content_block) if @story.content_block -%>
-<%- end -%>
-<%- else -%>
-<%= render_component(@story.component) do |c| -%>
-  <% @story.slots.each do |slot| -%>
-    <%- slot.call do -%>
-      <%= instance_eval(&slot.content_block) if slot.content_block -%>
-    <%- end -%>
-  <%- end -%>
-  <%- instance_eval(&@story.content_block) if @story.content_block -%>
-<%- end -%>
 <%- end -%>


### PR DESCRIPTION
Hi there,

`view_component` has an option to disable the monkey patch on the `render` method. This helps dealing with conflicts arising from the use of gems such as wickedpdf (which also monkey patch render). 

When the `render_monkey_patch_enabled` is set to `false` and therefore disabled, it allows you to user `render_component` instead of `render`. 

This (rough) PR is a proof of concept for allowing the use of `render_component` with `view_component_storybook`. This solution is copied from [`view_components/preview.html.erb`](https://github.com/github/view_component/blob/dac225f27f60b5b19d4ffac5208f726c095d162a/app/views/view_components/preview.html.erb)

Some possible improvements:
- define a different render method (`render_story`?) that implements the conditional use of `render` vs `render_component`.
- Tests. I tried getting a test but got distracted and didn't get very far. 

I wanted to open this PR already to get some feedback on it.