### PR TITLE
fix: Use stories_paths rather than stories_path in Rake task

### DIFF
--- a/lib/view_component/storybook/tasks/view_component_storybook.rake
+++ b/lib/view_component/storybook/tasks/view_component_storybook.rake
@@ -21,11 +21,13 @@ namespace :view_component_storybook do
   task remove_stories_json: :environment do
     puts "Removing old Stories JSON"
     exceptions = []
-    Dir["#{ViewComponent::Storybook.stories_path}/**/*.stories.json"].sort.each do |file|
-      puts file
-      File.unlink(file)
-    rescue StandardError => e
-      exceptions << e
+    ViewComponent::Storybook.stories_paths.each do |path|
+      Dir["#{path}/**/*.stories.json"].sort.each do |file|
+        puts file
+        File.unlink(file)
+      rescue StandardError => e
+        exceptions << e
+      end
     end
 
     raise StandardError, exceptions.map(&:message).join(", ") if exceptions.present?


### PR DESCRIPTION
`stories_path` was replaced with the array `stories_paths`; this PR runs the removal for each path in the `stories_paths` array.

Fixes #161 