### PR TITLE
Update gem name in installation instructions

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -13,7 +13,7 @@ nav_order: 1
 
 1. In `Gemfile`, add:
    ```ruby
-   gem "view_component_storybook"
+   gem "view_component-storybook"
    ```
 2. In`.gitignore`, add:
    ```text


### PR DESCRIPTION
The gem name changed from `view_component_storybook` to `view_component-storybook` with v1.0.0, but the installation instructions still refer to the old name.